### PR TITLE
fix(totp): fixes bug where totp form is enabled with no input

### DIFF
--- a/packages/fxa-settings/src/components/PageTwoStepAuthentication/index.tsx
+++ b/packages/fxa-settings/src/components/PageTwoStepAuthentication/index.tsx
@@ -289,7 +289,7 @@ export const PageTwoStepAuthentication = (_: RouteComponentProps) => {
                 data-testid="submit-totp"
                 className="cta-primary mx-2 flex-1"
                 disabled={
-                  !totpForm.formState.isDirty || !totpForm.formState.isValid
+                  !totpForm.formState.isValid
                 }
               >
                 Continue
@@ -378,7 +378,6 @@ export const PageTwoStepAuthentication = (_: RouteComponentProps) => {
                 data-testid="submit-recovery-code"
                 className="cta-primary mx-2 flex-1"
                 disabled={
-                  !recoveryCodeForm.formState.isDirty ||
                   !recoveryCodeForm.formState.isValid
                 }
               >


### PR DESCRIPTION
## Because

-Continue"/ "Finish" button becomes enabled when user clicks outside the code field at the first attempt

## This pull request

-solves the above issue.

## Issue that this pull request solves

Closes: #7738

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

